### PR TITLE
Check github app execution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,3 +32,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist
+        cname: # Optional: add your custom domain here if you have one

--- a/dist/index.html
+++ b/dist/index.html
@@ -31,7 +31,7 @@
             z-index: 1000;
         }
     </style>
-  <script type="module" crossorigin src="/assets/index-CO7WPVjn.js"></script>
+  <script type="module" crossorigin src="./assets/index-CO7WPVjn.js"></script>
 </head>
 <body>
     <div class="instructions">

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+    base: './', // Use relative paths for GitHub Pages
     server: {
         port: 3000,
         open: true


### PR DESCRIPTION
Configure Vite to use relative paths for assets to enable correct GitHub Pages deployment.

The previous Vite build generated absolute paths for assets (e.g., `/assets/index.js`), which prevented the application from loading correctly on GitHub Pages. This change adds `base: './'` to `vite.config.js` to ensure all asset paths are relative, resolving the deployment issue. A minor comment for custom domains was also added to the GitHub Actions workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7c95a9c-9ed7-47cf-ac44-5d333b199d2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7c95a9c-9ed7-47cf-ac44-5d333b199d2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

